### PR TITLE
Fixed url encoding bug

### DIFF
--- a/GoogleMaps.LocationServices.Console/Program.cs
+++ b/GoogleMaps.LocationServices.Console/Program.cs
@@ -25,6 +25,12 @@ namespace GoogleMaps.LocationServices.Console
                     Address = "1600 Pennsylvania ave",
                     City = "Washington",
                     State = "DC"
+                },
+                new AddressData
+                {
+                    Address = "407 N Maple Dr. #1",
+                    City = "Beverly Hills",
+                    State = "CA"
                 }
             };
 

--- a/GoogleMaps.LocationServices/GoogleLocationService.cs
+++ b/GoogleMaps.LocationServices/GoogleLocationService.cs
@@ -111,7 +111,7 @@ namespace GoogleMaps.LocationServices
         /// <returns></returns>
         public MapPoint GetLatLongFromAddress(string address)
         {
-            XDocument doc = XDocument.Load(string.Format(APIUrlLatLongFromAddress, address));
+            XDocument doc = XDocument.Load(string.Format(APIUrlLatLongFromAddress, Uri.EscapeDataString(address)));
             var els = doc.Descendants("result").Descendants("geometry").Descendants("location").First();
             if (null != els)
             {
@@ -155,7 +155,9 @@ namespace GoogleMaps.LocationServices
         {
             Directions direction = new Directions();
 
-            XDocument xdoc = XDocument.Load(String.Format(APIUrlDirections, originAddress.ToString(), destinationAddress.ToString()));
+            XDocument xdoc = XDocument.Load(String.Format(APIUrlDirections,
+                Uri.EscapeDataString(originAddress.ToString()),
+                Uri.EscapeDataString(destinationAddress.ToString())));
 
             var status = (from s in xdoc.Descendants("DirectionsResponse").Descendants("status")
                           select s).FirstOrDefault();


### PR DESCRIPTION
Thanks for the handy NuGet package.

I noticed a small bug w/ url encoding b/c I have a few addresses in my database w/ suite numbers in them. (123 Foo St. #12)

The # wasn't getting encoded correctly so I fixed that.
