### PR TITLE
Throw an exception on Gmaps API quota limit or authorization failure

### DIFF
--- a/GoogleMaps.LocationServices.Console/Program.cs
+++ b/GoogleMaps.LocationServices.Console/Program.cs
@@ -37,10 +37,18 @@ namespace GoogleMaps.LocationServices.Console
             var gls = new GoogleLocationService();
             foreach (var address in addresses)
             {
-                var latlong = gls.GetLatLongFromAddress(address);
-                var Latitude = latlong.Latitude;
-                var Longitude = latlong.Longitude;
-                System.Console.WriteLine("Address ({0}) is at {1},{2}", address, Latitude, Longitude);
+                try
+                {
+                    var latlong = gls.GetLatLongFromAddress(address);
+                    var Latitude = latlong.Latitude;
+                    var Longitude = latlong.Longitude;
+                    System.Console.WriteLine("Address ({0}) is at {1},{2}", address, Latitude, Longitude);
+                }
+                catch(System.Net.WebException ex)
+                {
+                    System.Console.WriteLine("Google Maps API Error {0}", ex.Message);
+                }
+                
             }
             System.Console.ReadLine();
         }

--- a/GoogleMaps.LocationServices/GoogleLocationService.cs
+++ b/GoogleMaps.LocationServices/GoogleLocationService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Security.Authentication;
 using System.Text;
 using System.Xml.Linq;
 
@@ -109,9 +110,17 @@ namespace GoogleMaps.LocationServices
         /// </summary>
         /// <param name="address">The address.</param>
         /// <returns></returns>
+        /// <exception cref="System.Net.WebException"></exception>
         public MapPoint GetLatLongFromAddress(string address)
         {
             XDocument doc = XDocument.Load(string.Format(APIUrlLatLongFromAddress, Uri.EscapeDataString(address)));
+
+            string status = doc.Descendants("status").FirstOrDefault().Value;
+            if (status == "OVER_QUERY_LIMIT" || status == "REQUEST_DENIED")
+            {
+                throw new System.Net.WebException("Request Not Authorized or Over QueryLimit");
+            }
+
             var els = doc.Descendants("result").Descendants("geometry").Descendants("location").FirstOrDefault();
             if (null != els)
             {


### PR DESCRIPTION
Added a System.Net.WebExcetion when the Google Maps API returns a status of NotAuthorized or OverQuotaLimit. This was necessary to handle delaying batch jobs for 24 hours if we were in a quota violation state. 