### PR TITLE
added GetAddressListFromAddress feature

### DIFF
--- a/GoogleMaps.LocationServices/GoogleLocationService.cs
+++ b/GoogleMaps.LocationServices/GoogleLocationService.cs
@@ -231,6 +231,40 @@ namespace GoogleMaps.LocationServices
             return GetLatLongFromAddress(address.ToString());
         }
 
+        /// <summary>
+        /// Gets an array of string addresses that matched a possibly ambiguous address.
+        /// </summary>
+        /// <param name="address">The address.</param>
+        /// <returns></returns>
+        /// <exception cref="System.Net.WebException"></exception>
+        public string[] GetAddressesListFromAddress(string address)
+        {
+
+            XDocument doc = XDocument.Load(string.Format(APIUrlLatLongFromAddress, Uri.EscapeDataString(address)));
+            var status = doc.Descendants("status").FirstOrDefault().Value;
+
+            if (status == "OVER_QUERY_LIMIT" || status == "REQUEST_DENIED")
+            {
+                throw new System.Net.WebException("Request Not Authorized or Over QueryLimit");
+            }
+
+            var results = doc.Descendants("result").Descendants("formatted_address").ToArray();
+            var addresses = (from elem in results select elem.Value).ToArray();
+            if (addresses.Length > 0) return addresses;
+            return null;
+        }
+
+        /// <summary>
+        /// Gets an array of string addresses that matched a possibly ambiguous address.
+        /// </summary>
+        /// <param name="address">The address.</param>
+        /// <returns></returns>
+        /// <exception cref="System.Net.WebException"></exception>
+        public string[] GetAddressesListFromAddress(AddressData address)
+        {
+            return GetAddressesListFromAddress(address.ToString());
+        }
+
 
         /// <summary>
         /// Gets the directions.


### PR DESCRIPTION
Google API's are getting a list of addresses from an ambiguous address as input. This can led to unexpected behaviour on getting latitude and longitude from an ambiguous address. This method simply return the list of addresses from Google API's and then - after a user input choice, for example - it's possible to geolocalize a place without errors from a "Google known" address string.