### PR TITLE
Added null check for typename variable

### DIFF
--- a/GoogleMaps.LocationServices/GoogleLocationService.cs
+++ b/GoogleMaps.LocationServices/GoogleLocationService.cs
@@ -148,7 +148,7 @@ namespace GoogleMaps.LocationServices
             {
                 var longname = xn["long_name"].InnerText;
                 var shortname = xn["short_name"].InnerText;
-                var typename = xn["type"].InnerText;
+                var typename = xn["type"]?.InnerText;
 
                 switch (typename)
                 {


### PR DESCRIPTION
Added null check for typename variable to prevent null reference exception when no type field exists. 

Example here: https://maps.googleapis.com/maps/api/geocode/xml?latlng=-36.2194127,174.5664288